### PR TITLE
Replace underscore with lodash

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -44,7 +44,7 @@ module.exports = function (grunt) {
         this.requires("connect");
 
         var WebTestRunner = require("./").WebTestRunner,
-            _ = require("underscore"),
+            _ = require("lodash"),
             done = this.async(),
             grid = grunt.config.get("seleniumGrid") || {
                 host: "127.0.0.1",

--- a/config.json
+++ b/config.json
@@ -44,7 +44,7 @@
         "flow": "js/lib/flow",
         "Query": "js/lib/query/query",
         "inherit": "js/lib/inherit",
-        "underscore": "js/lib/underscore",
+        "underscore": "js/lib/lodash",
         "moment": "js/lib/moment",
         "JSON": "js/lib/json2.js",
         "RestConditionParser": "srv/lib/RestConditionParser"

--- a/lib/TestRunner.js
+++ b/lib/TestRunner.js
@@ -1,7 +1,7 @@
 var requirejs = require('requirejs'),
     inherit = require('inherit.js').inherit,
     path = require('path'),
-    _ = require('underscore'),
+    _ = require('lodash'),
     flow = require('flow.js').flow,
     findXamlClasses = require('./findXamlClasses'),
 

--- a/lib/WebTestRunner.js
+++ b/lib/WebTestRunner.js
@@ -1,6 +1,6 @@
 module.exports = function(options, moduleCallback) {
 
-    var _ = require("underscore"),
+    var _ = require("lodash"),
         fs = require("fs"),
         path = require("path"),
         Mocha = require("mocha"),

--- a/package.json
+++ b/package.json
@@ -44,7 +44,8 @@
     "colors": "*",
     "xmlhttprequest": "latest",
     "xmldom": "0.1.15",
-    "esprima": "latest"
+    "esprima": "latest",
+    "lodash": "~2.4.1"
   },
   "optionalDependencies": {},
   "devDependencies": {


### PR DESCRIPTION
I used current version of lodash (2.4). For frontend i used the strict mode compliant version of lodash. It is also possible to use different versions of lodash for legacy and modern browsers. It is even possible to only use parts of lodash. This can possibly slim down you footprint, since you only use parts of underscore. therefor you must require only the function you want to use and not the whole library. This may be a little more work to do, because you have to review every require.
