### PR TITLE
renamed TileList property 'aspectRatio' to 'itemAspectRatio' because of name conflicts

### DIFF
--- a/doc/js.ui.TileList.json
+++ b/doc/js.ui.TileList.json
@@ -160,8 +160,8 @@
             ],
             "definedBy": "js.ui.TileListClass"
         },
-        "aspectRatio": {
-            "name": "aspectRatio",
+        "itemAspectRatio": {
+            "name": "itemAspectRatio",
             "defaultType": "value",
             "visibility": "public",
             "value": 1,

--- a/doc/js.ui.TileListClass.json
+++ b/doc/js.ui.TileListClass.json
@@ -3646,8 +3646,8 @@
                 "Number"
             ]
         },
-        "aspectRatio": {
-            "name": "aspectRatio",
+        "itemAspectRatio": {
+            "name": "itemAspectRatio",
             "defaultType": "value",
             "visibility": "public",
             "value": 1,

--- a/js/ui/TileListClass.js
+++ b/js/ui/TileListClass.js
@@ -52,7 +52,7 @@ define(['js/ui/VirtualItemsView'], function (VirtualItemsView) {
              *
              * @type Number
              */
-            aspectRatio: 1,
+            itemAspectRatio: 1,
 
             horizontalGap: 10,
             /**
@@ -98,7 +98,7 @@ define(['js/ui/VirtualItemsView'], function (VirtualItemsView) {
 
         _commitChangedAttributes: function ($) {
 
-            if (this._hasSome($, ["itemWidth", "itemHeight", "aspectRation", "width", "height", "verticalGap", "horizontalGap"])) {
+            if (this._hasSome($, ["itemWidth", "itemHeight", "itemAspectRatio", "width", "height", "verticalGap", "horizontalGap"])) {
 
                 var cols = this.$.cols,
                     rows = this.$.rows,
@@ -110,7 +110,7 @@ define(['js/ui/VirtualItemsView'], function (VirtualItemsView) {
                     leftPadding = this.$.leftPadding,
                     itemWidth = this.$.itemWidth,
                     itemHeight = this.$.itemHeight,
-                    aspectRatio = this.$.aspectRatio,
+                    itemAspectRatio = this.$.itemAspectRatio,
                     scrollBarSize = this.$._scrollBarSize || 0,
                     setValues = true;
 
@@ -132,7 +132,7 @@ define(['js/ui/VirtualItemsView'], function (VirtualItemsView) {
                     }
 
                     if (itemHeight === AUTO) {
-                        itemHeight = itemWidth * aspectRatio;
+                        itemHeight = itemWidth * itemAspectRatio;
                     }
                 } else if (height != null && this.$.scrollDirection === VirtualItemsView.SCROLL_DIRECTION_HORIZONTAL) {
                     if (rows === AUTO) {
@@ -150,7 +150,7 @@ define(['js/ui/VirtualItemsView'], function (VirtualItemsView) {
                     }
 
                     if (itemWidth === AUTO) {
-                        itemWidth = itemHeight * aspectRatio;
+                        itemWidth = itemHeight * itemAspectRatio;
                     }
                 } else {
                     setValues = false;

--- a/xsd/js.ui.xsd
+++ b/xsd/js.ui.xsd
@@ -1494,7 +1494,7 @@ Possible values are "horizontal" and "vertical"
                     </documentation>
                     </annotation>
                 </attribute>
-                <attribute name="aspectRatio" initializeInvisibleChildren="false" default="1">
+                <attribute name="itemAspectRatio" initializeInvisibleChildren="false" default="1">
                     <annotation initializeInvisibleChildren="false">
                         <documentation initializeInvisibleChildren="false">
                         calculates itemHeight, itemWidth if set to AUTO depending on the scrollDirection
@@ -1571,7 +1571,7 @@ Possible values are "horizontal" and "vertical"
                     </documentation>
                     </annotation>
                 </attribute>
-                <attribute name="aspectRatio" initializeInvisibleChildren="false" default="1">
+                <attribute name="itemAspectRatio" initializeInvisibleChildren="false" default="1">
                     <annotation initializeInvisibleChildren="false">
                         <documentation initializeInvisibleChildren="false">
                         calculates itemHeight, itemWidth if set to AUTO depending on the scrollDirection


### PR DESCRIPTION
Chrome v88 introduced a new css property called ```aspect-ratio```. The TileListClass.js uses an attribute called ```aspectRatio```.
The attribute gets misinterpreted and rAppid applies the css property ```aspect-ratio: 1 / 1``` to the TileList element. 

To avoid this problem, i renamed the attribute ```aspectRatio``` to ```itemAspectRatio```.